### PR TITLE
Forcing cookies to "SameSite=None Secure"

### DIFF
--- a/pusher/src/Controller/AuthenticateController.ts
+++ b/pusher/src/Controller/AuthenticateController.ts
@@ -103,6 +103,8 @@ export class AuthenticateController extends BaseHttpController {
                 const loginUri = await openIDClient.authorizationUrl(res, query.redirect, query.playUri);
                 res.cookie("playUri", query.playUri, undefined, {
                     httpOnly: true,
+                    sameSite: "none",
+                    secure: true,
                 });
 
                 return res.redirect(loginUri);

--- a/pusher/src/Services/OpenIDClient.ts
+++ b/pusher/src/Services/OpenIDClient.ts
@@ -70,6 +70,8 @@ class OpenIDClient {
             // it should be httpOnly (not readable by javascript) and encrypted.
             res.cookie("code_verifier", this.encrypt(code_verifier), undefined, {
                 httpOnly: true,
+                sameSite: "none",
+                secure: true,
             });
 
             // We also store the state in cookies. The state should not be needed, except for older OpenID client servers that
@@ -77,6 +79,8 @@ class OpenIDClient {
             const state = uuid();
             res.cookie("oidc_state", state, undefined, {
                 httpOnly: true,
+                sameSite: "none",
+                secure: true,
             });
 
             const code_challenge = generators.codeChallenge(code_verifier);


### PR DESCRIPTION
Putting cookies in "SameSite=None Secure" mode to avoid a warning by Firefox and try to have a website that can run in Iframes.