### PR TITLE
Removing a deprecated loginurl endpoint from external API doc

### DIFF
--- a/pusher/src/Controller/SwaggerController.ts
+++ b/pusher/src/Controller/SwaggerController.ts
@@ -173,40 +173,6 @@ export class SwaggerController extends BaseHttpController {
                             },
                         },
                     },
-                    "/api/loginurl/{organizationMemberToken}": {
-                        get: {
-                            security: [
-                                {
-                                    Header: [],
-                                },
-                            ],
-                            description: "Returns a member from the token",
-                            tags: ["ExternalAdminAPI"],
-                            parameters: [
-                                {
-                                    name: "organizationMemberToken",
-                                    in: "path",
-                                    description: "The token of member in the organization",
-                                    required: true,
-                                    type: "string",
-                                },
-                            ],
-                            responses: {
-                                200: {
-                                    description: "The details of the member",
-                                    schema: {
-                                        $ref: "#/definitions/AdminApiData",
-                                    },
-                                },
-                                401: {
-                                    description: "Error while retrieving the data because you are not authorized",
-                                    schema: {
-                                        $ref: "#/definitions/ErrorApiUnauthorizedData",
-                                    },
-                                },
-                            },
-                        },
-                    },
                 },
             };
             res.json(options);

--- a/pusher/src/Services/SwaggerGenerator.ts
+++ b/pusher/src/Services/SwaggerGenerator.ts
@@ -14,7 +14,6 @@ class SwaggerGenerator {
     definitions(type: string | null) {
         const definitions = {
             definitions: {
-                AdminApiData: generateSchema(isAdminApiData),
                 ErrorApiUnauthorizedData: generateSchema(isErrorApiUnauthorizedData),
                 FetchMemberDataByUuidResponse: generateSchema(isFetchMemberDataByUuidResponse),
                 MapDetailsData: generateSchema(isMapDetailsData),


### PR DESCRIPTION
The loginurl admin endpoint was used by the /register endpoint. But /register was deprecated. So the loginurl endpoint itself does not need to be implemented anymore by AdminAPI implementors.