### PR TITLE
Putting Front CI build inside a build matrix

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,7 +12,9 @@ jobs:
   build-front:
     if: ${{ github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        platform: [linux/amd64,linux/arm64]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +59,7 @@ jobs:
         with:
           context: .
           file: front/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
           tags: thecodingmachine/workadventure-front:${{ github.event_name == 'pull_request' && env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This should speed up Github Actions by starting 2 jobs instead of 1 for front container building