### PR TITLE
Allow setting player name from the back-end

### DIFF
--- a/front/src/Components/Menu/ProfileSubMenu.svelte
+++ b/front/src/Components/Menu/ProfileSubMenu.svelte
@@ -19,6 +19,8 @@
     import Companion from "../Companion/Companion.svelte";
     import LL from "../../i18n/i18n-svelte";
 
+    let canEditName = !gameManager.getCurrentGameScene().room.constrainedName;
+
     function disableMenuStores() {
         menuVisiblilityStore.set(false);
         menuIconVisiblilityStore.set(false);
@@ -62,10 +64,12 @@
 <div class="customize-main">
     <div class="submenu">
         <section>
-            <button type="button" class="nes-btn" on:click|preventDefault={openEditNameScene}>
-                <img src={btnProfileSubMenuIdentity} alt={$LL.menu.profile.edit.name()} />
-                <span class="btn-hover">{$LL.menu.profile.edit.name()}</span>
-            </button>
+            {#if canEditName}
+                <button type="button" class="nes-btn" on:click|preventDefault={openEditNameScene}>
+                    <img src={btnProfileSubMenuIdentity} alt={$LL.menu.profile.edit.name()} />
+                    <span class="btn-hover">{$LL.menu.profile.edit.name()}</span>
+                </button>
+            {/if}
             <button type="button" class="nes-btn" on:click|preventDefault={openEditSkinScene}>
                 <Woka userId={-1} placeholderSrc="" width="26px" height="26px" />
                 <span class="btn-hover">{$LL.menu.profile.edit.woka()}</span>

--- a/front/src/Connexion/Room.ts
+++ b/front/src/Connexion/Room.ts
@@ -32,6 +32,8 @@ export class Room {
     private _group: string | null = null;
     private _expireOn: Date | undefined;
     private _canReport: boolean = false;
+    private _playerName: string | undefined;
+    private _constrainedName: boolean = false;
 
     private constructor(private roomUrl: URL) {
         this.id = roomUrl.pathname;
@@ -128,6 +130,15 @@ export class Room {
                     this._expireOn = new Date(data.expireOn);
                 }
                 this._canReport = data.canReport ?? false;
+                this._playerName = data.playerName;
+                this._constrainedName = data.constrainedName ?? false;
+
+                if (this._playerName === undefined && this._constrainedName) {
+                    throw new Error(
+                        "The backend did not send any user name. Yet, the user name can only be set by the backend for this map."
+                    );
+                }
+
                 return new MapDetail(data.mapUrl, data.textures);
             } else {
                 throw new Error("Data received by the /map endpoint of the Pusher is not in a valid format.");
@@ -238,5 +249,19 @@ export class Room {
 
     get canReport(): boolean {
         return this._canReport;
+    }
+
+    /**
+     * Returns the player name, as stored in the backend (if the backend stores it)
+     */
+    get playerName(): string | undefined {
+        return this._playerName;
+    }
+
+    /**
+     * If true, the backend has complete control of the player name and the player cannot change it.
+     */
+    get constrainedName(): boolean {
+        return this._constrainedName;
     }
 }

--- a/front/src/Phaser/Game/GameManager.ts
+++ b/front/src/Phaser/Game/GameManager.ts
@@ -33,6 +33,13 @@ export class GameManager {
     public async init(scenePlugin: Phaser.Scenes.ScenePlugin): Promise<string> {
         this.scenePlugin = scenePlugin;
         this.startRoom = await connectionManager.initGameConnexion();
+
+        // If the backend sent a name to us, and if we don't already have a name set (or if the name is compulsory), let's store it in local storage.
+        if (this.startRoom.playerName && (!this.playerName || this.startRoom.constrainedName)) {
+            this.playerName = this.startRoom.playerName;
+            localUserStore.setName(this.playerName);
+        }
+
         this.loadMap(this.startRoom);
 
         //If player name was not set show login scene with player name

--- a/front/src/Phaser/Game/GameScene.ts
+++ b/front/src/Phaser/Game/GameScene.ts
@@ -219,7 +219,7 @@ export class GameScene extends DirtyScene {
     private lastCameraEvent: WasCameraUpdatedEvent | undefined;
     private firstCameraUpdateSent: boolean = false;
 
-    constructor(private room: Room, MapUrlFile: string, customKey?: string | undefined) {
+    constructor(public readonly room: Room, MapUrlFile: string, customKey?: string | undefined) {
         super({
             key: customKey ?? room.key,
         });

--- a/messages/JsonMessages/MapDetailsData.ts
+++ b/messages/JsonMessages/MapDetailsData.ts
@@ -24,6 +24,10 @@ export const isMapDetailsData = new tg.IsInterface()
         expireOn: tg.isString,
         // Whether the "report" feature is enabled or not on this room
         canReport: tg.isBoolean,
+        /// The name of the player to be displayed.
+        playerName: tg.isString,
+        /// If true, the "admin" component forces the name of the users. The "Select you name" screen will *never* be displayed.
+        constrainedName: tg.isBoolean,
     })
     .get();
 


### PR DESCRIPTION
This commit adds 2 new properties that can be sent fromt the "/map" endpoint of the pusher / admin:

- playerName (string)
- constrainedName (boolean)

If "playerName" is set and the local storage is empty, playerName is used by default. If "playerName" is set and "constrainedName" is true, playerName is used and overrides the local storage.

If "constrainedName" is true, the user cannot access the "edit your name" screen at all.